### PR TITLE
Added the standard rOpenSci footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,6 @@ z[,c("authors", "title")]
 ### License
 
 Licensed under the [MIT license](http://cran.r-project.org/web/licenses/MIT). ([More information here](http://en.wikipedia.org/wiki/MIT_License).)
+
+[![ropensci footer](http://ropensci.org/public_images/github_footer.png)](http://ropensci.org)
+


### PR DESCRIPTION
Hi @kbroman 
I added the standard ropensci footer to your readme.

![image](https://cloud.githubusercontent.com/assets/138494/4725051/344b72be-5956-11e4-9951-5710a402a7c8.png)
