### PR TITLE
Fix the failing tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,6 @@
-language: c
-before_install:
-- curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
-- chmod 755 ./travis-tool.sh
-- "./travis-tool.sh bootstrap"
-install:
-- "./travis-tool.sh install_deps"
-script: "./travis-tool.sh run_tests"
-after_failure:
-- "./travis-tool.sh dump_logs"
+language: r
+sudo: required
+
 notifications:
   email:
     on_success: change

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: IEEER
 Title: Interface to the IEEE Xplore Gateway
-Version: 0.2.7
-Date: 2016-01-14
+Version: 0.2.8
+Date: 2016-03-30
 Authors@R: c(person("Saul", "Wiggin", role=c("aut","cre"),
     email="saulwiggin@googlemail.com"),
     person("Karl", "Broman", role="aut",

--- a/tests/testthat/test-search.R
+++ b/tests/testthat/test-search.R
@@ -20,14 +20,14 @@ test_that("IEEE_count and IEEE_search work in a simple case", {
                 "An approach to the approximation problem for nonrecursive digital filters",
                 "Synthetic voices for computers",
                 "The design of wide-band recursive and nonrecursive digital differentiators")
-    authors <- c("Rader, C.M.;  Rabiner, L.R.;  Schafer, R.W.",
-                 "Rabiner, L.;  Gold, B.;  McGonegal, C.",
-                 "Flanagan, J.L.;  Coker, C.;  Rabiner, L.;  Schafer, R.W.;  Umeda, N.",
-                 "Rabiner, L.;  Steiglitz, K.")
-    pubtitle <- c("Bell System Technical Journal, The",
-                   "Audio and Electroacoustics, IEEE Transactions on",
-                   "Spectrum, IEEE",
-                   "Audio and Electroacoustics, IEEE Transactions on")
+    authors <- c("C. M. Rader;  L. R. Rabiner;  R. W. Schafer",
+                 "L. Rabiner;  B. Gold;  C. McGonegal",
+                 "J. L. Flanagan;  C. H. Coker;  L. R. Rabiner;  R. W. Schafer;  N. Umeda",
+                 "L. Rabiner;  K. Steiglitz")
+    pubtitle <- c("The Bell System Technical Journal",
+                   "IEEE Transactions on Audio and Electroacoustics",
+                   "IEEE Spectrum",
+                   "IEEE Transactions on Audio and Electroacoustics")
 
     expect_equal(result$title, titles)
     expect_equal(result$authors, authors)


### PR DESCRIPTION
- Finally passing on Travis again
- For a while IEEE Explore Gateway was returning blank author field; that's no longer a problem, but they did change the format of the author and journal name fields; revised tests to match
- Also revised the `.travis.yml` file