### PR TITLE
change travis file to cache: packages and sudo: false to speed up builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: r
-sudo: required
+sudo: false
+cache: packages
 
 after_success:
 - Rscript -e 'covr::codecov()'


### PR DESCRIPTION
hey-o  - going through all ropensci repos trying to speed up Travis builds by using container based builds whenever possible 

the build https://travis-ci.org/ropensci/IEEER/builds/209074873 isn't faster than the others on the first run, but should be faster the next time since deps are cached

also, build failed, but due to failed test, not to changes made here