### PR TITLE
Skip most tests when not interactive

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: IEEER
 Title: Interface to the IEEE Xplore Gateway
-Version: 0.2.8
-Date: 2016-03-30
+Version: 0.2.9
+Date: 2017-03-24
 Authors@R: c(person("Saul", "Wiggin", role=c("aut","cre"),
     email="saulwiggin@googlemail.com"),
     person("Karl", "Broman", role="aut",

--- a/tests/testthat/test-batches.R
+++ b/tests/testthat/test-batches.R
@@ -2,6 +2,8 @@ context("IEEER_search in batches")
 
 test_that("batch search gives same result as all together", {
 
+    if(!interactive()) skip("this test only run locally")
+
     # shorter delay to speed tests
     old_delay <- getOption("IEEER_delay")
     on.exit(options(IEEER_delay=old_delay))

--- a/tests/testthat/test-search.R
+++ b/tests/testthat/test-search.R
@@ -2,6 +2,8 @@ context("basic searches")
 
 test_that("IEEE_count and IEEE_search work in a simple case", {
 
+    if(!interactive()) skip("this test only run locally")
+
     # shorter delay to speed tests
     old_delay <- getOption("IEEER_delay")
     on.exit(options(IEEER_delay=old_delay))


### PR DESCRIPTION
 - We've had repeated difficulties with the servers occassionally
   returning results in a different format and resulting in failed
   tests.

 - Skipping these tests when not interactive.